### PR TITLE
第二次调用该方法时，没有清空$this->method导致找不到该方法

### DIFF
--- a/src/PingppCollertion.php
+++ b/src/PingppCollertion.php
@@ -16,6 +16,7 @@ class PingppCollertion
                 if (method_exists('Pingpp\\' . $this->method, $method)) {
                     $func = 'Pingpp\\' . $this->method . '::' . $method;
                     $ret = forward_static_call_array($func, $arg_array);
+                    $this->method = null;
                     return $ret;
                 }
             } else {


### PR DESCRIPTION
调方法成功后应该清空$this->method，否则第二次调用该方法时，因为没有清空$this->method导致找不到该方法